### PR TITLE
Add custom image that waits for istio sidecar

### DIFF
--- a/Dockerfile.wait-for-istio-proxy
+++ b/Dockerfile.wait-for-istio-proxy
@@ -32,7 +32,7 @@ WORKDIR /var/lib/fortio
 
 RUN apt update -y && apt install curl -y
 
-COPY entrypoint.sh /entrypoint.sh
+COPY entrypoint-wait-for-istio-proxy.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 # start the server mode (grpc ping on 8079, http echo and UI on 8080, redirector on 8081) by default
 CMD ["server"]

--- a/entrypoint-wait-for-istio-proxy.sh
+++ b/entrypoint-wait-for-istio-proxy.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# This entrypoint will wait for istio-proxy to be available
+
+echo "Wait man"
+
+count=30
+until curl -I localhost:15000; do
+	echo Waiting for Sidecar
+	count=$((count - 1))
+	sleep 2
+
+	if [ $count -lt 0 ]; then
+		echo "Bypassing sidecar check, took too long (60s++)"
+		break
+	fi
+done
+
+echo Starting fortio "$@" in 10s
+sleep 10 # Sometimes still need a few seconds after its "Ready"
+/usr/bin/fortio "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo Starting fortio "$@"
+/usr/bin/fortio "$@"


### PR DESCRIPTION
The "wait" is needed when running `fortio` inside istio service mesh, sidecars need time to boot up.

* Also changed the base image to Ubuntu:18.04